### PR TITLE
test: add upgrade verification and import path resolution tests

### DIFF
--- a/__tests__/functions/ipfs/node.test.js
+++ b/__tests__/functions/ipfs/node.test.js
@@ -7,9 +7,14 @@ jest.mock('data/protobuf/SGTransaction', () => ({
   TransferUTXOInput: { create: jest.fn() },
 }), { virtual: true });
 
-jest.mock('data/protobuf/delta', () => ({
+jest.mock('data/protobuf/crdt/delta', () => ({
   Delta: { create: jest.fn() },
   Element: { create: jest.fn() },
+}), { virtual: true });
+
+jest.mock('data/protobuf/crdt/bcast', () => ({
+  CRDTBroadcast: { create: jest.fn() },
+  Head: { create: jest.fn() },
 }), { virtual: true });
 
 jest.mock('data/protobuf/SGBlocks', () => ({
@@ -28,7 +33,7 @@ describe('IPFS Node Functions', () => {
   it('should have mocked protobuf dependencies', () => {
     // Test that the protobuf mocks are working
     expect(jest.isMockFunction(require('data/protobuf/SGTransaction').MintTx.create)).toBe(true);
-    expect(jest.isMockFunction(require('data/protobuf/delta').Delta.create)).toBe(true);
+    expect(jest.isMockFunction(require('data/protobuf/crdt/delta').Delta.create)).toBe(true);
     expect(jest.isMockFunction(require('data/protobuf/SGBlocks').BlockID.create)).toBe(true);
   });
 

--- a/__tests__/upgrade/functionality-preservation.test.js
+++ b/__tests__/upgrade/functionality-preservation.test.js
@@ -1,0 +1,153 @@
+// Test for existing functionality preservation
+const fs = require('fs');
+const path = require('path');
+
+describe('Existing Functionality Preservation Tests', () => {
+  test('all existing test suites should still pass', () => {
+    // This test verifies that the upgrade hasn't broken existing functionality
+    // by checking that key test files still exist and are properly structured
+    
+    const testFiles = [
+      '__tests__/basic.test.js',
+      '__tests__/functions/ipfs/node.test.js',
+      '__tests__/functions/messages/processing.test.js',
+      '__tests__/hooks/ipfs/useIPFS.test.js',
+      '__tests__/hooks/prices/usePrices.test.js',
+      '__tests__/components/dashboard/BlockchainInfo.test.jsx',
+      '__tests__/components/job-order/OrderForm.test.jsx',
+      '__tests__/pages/index.test.jsx'
+    ];
+    
+    testFiles.forEach(testFile => {
+      const fullPath = path.join(__dirname, '../../', testFile);
+      expect(fs.existsSync(fullPath)).toBe(true);
+      
+      const content = fs.readFileSync(fullPath, 'utf8');
+      
+      // Should have describe blocks
+      expect(content).toMatch(/describe\(/);
+      
+      // Should have test cases
+      expect(content).toMatch(/test\(|it\(/);
+    });
+  });
+
+  test('core functionality modules should remain intact', () => {
+    const coreModules = [
+      'functions/ipfs/node.ts',
+      'functions/messages/processing.ts',
+      'functions/messages/transfer.ts',
+      'functions/messages/mint.ts',
+      'functions/messages/escrow.ts',
+      'functions/messages/block.ts'
+    ];
+    
+    coreModules.forEach(modulePath => {
+      const fullPath = path.join(__dirname, '../../', modulePath);
+      expect(fs.existsSync(fullPath)).toBe(true);
+      
+      const content = fs.readFileSync(fullPath, 'utf8');
+      
+      // Should have exports
+      expect(content).toMatch(/export/);
+    });
+  });
+
+  test('SDK functions should remain accessible', () => {
+    const nodePath = path.join(__dirname, '../../functions/ipfs/node.ts');
+    const content = fs.readFileSync(nodePath, 'utf8');
+    
+    // Core SDK functions should be exported (check for export block)
+    expect(content).toMatch(/export\s*\{[\s\S]*createNode[\s\S]*\}/);
+    expect(content).toMatch(/export\s*\{[\s\S]*shutdownGnus[\s\S]*\}/);
+    expect(content).toMatch(/export\s*\{[\s\S]*CheckTransactions[\s\S]*\}/);
+    expect(content).toMatch(/export\s*\{[\s\S]*getBalanceMinions[\s\S]*\}/);
+    expect(content).toMatch(/export\s*\{[\s\S]*mintTokens[\s\S]*\}/);
+    expect(content).toMatch(/export\s*\{[\s\S]*transferTokens[\s\S]*\}/);
+  });
+
+  test('message handling functions should remain functional', () => {
+    const messageFiles = [
+      'functions/messages/processing.ts',
+      'functions/messages/transfer.ts',
+      'functions/messages/mint.ts',
+      'functions/messages/escrow.ts',
+      'functions/messages/block.ts'
+    ];
+    
+    messageFiles.forEach(filePath => {
+      const fullPath = path.join(__dirname, '../../', filePath);
+      const content = fs.readFileSync(fullPath, 'utf8');
+      
+      // Should export default function
+      expect(content).toMatch(/export default/);
+      
+      // Should handle message parameter
+      expect(content).toMatch(/const \w+Msg.*=/);
+    });
+  });
+
+  test('protobuf transaction parsing should remain functional', () => {
+    const nodePath = path.join(__dirname, '../../functions/ipfs/node.ts');
+    const content = fs.readFileSync(nodePath, 'utf8');
+    
+    // Should have ParseTransaction function
+    expect(content).toMatch(/function ParseTransaction/);
+    
+    // Should parse all transaction types
+    expect(content).toMatch(/MintTx\.fromBinary/);
+    expect(content).toMatch(/ProcessingTx\.fromBinary/);
+    expect(content).toMatch(/EscrowTx\.fromBinary/);
+    
+    // Should call message handlers
+    expect(content).toMatch(/mintMsg\(/);
+    expect(content).toMatch(/processingMsg\(/);
+    expect(content).toMatch(/escrowMsg\(/);
+  });
+
+  test('transaction checking functionality should remain intact', () => {
+    const nodePath = path.join(__dirname, '../../functions/ipfs/node.ts');
+    const content = fs.readFileSync(nodePath, 'utf8');
+    
+    // Should have CheckTransactions function
+    expect(content).toMatch(/function CheckTransactions/);
+    
+    // Should get outgoing transactions
+    expect(content).toMatch(/getOutTransactions\(\)/);
+    
+    // Should get incoming transactions
+    expect(content).toMatch(/getInTransactions\(\)/);
+    
+    // Should free transaction memory
+    expect(content).toMatch(/freeTransactions/);
+    
+    // Should parse transactions
+    expect(content).toMatch(/ParseTransaction/);
+  });
+
+  test('data structures should remain compatible', () => {
+    const nodePath = path.join(__dirname, '../../functions/ipfs/node.ts');
+    const content = fs.readFileSync(nodePath, 'utf8');
+    
+    // Should import required structs
+    expect(content).toMatch(/GeniusArray.*getStruct.*GeniusMatrix.*GeniusAddress/);
+    
+    // Should define token structures
+    expect(content).toMatch(/GeniusTokenValue.*koffi\.struct/);
+    expect(content).toMatch(/GeniusTokenID.*koffi\.struct/);
+  });
+
+  test('backward compatibility should be maintained', () => {
+    const nodePath = path.join(__dirname, '../../functions/ipfs/node.ts');
+    const content = fs.readFileSync(nodePath, 'utf8');
+    
+    // Should still import from SGTransaction (existing workflow)
+    expect(content).toMatch(/require.*data\/protobuf\/SGTransaction/);
+    
+    // Should still import from SGBlocks (existing workflow)
+    expect(content).toMatch(/require.*data\/protobuf\/SGBlocks/);
+    
+    // Should have new CRDT imports (upgraded workflow)
+    expect(content).toMatch(/require.*data\/protobuf\/crdt/);
+  });
+});

--- a/__tests__/upgrade/import-path-resolution.test.js
+++ b/__tests__/upgrade/import-path-resolution.test.js
@@ -1,0 +1,189 @@
+// Property test for import path resolution
+const fs = require('fs');
+const path = require('path');
+
+describe('Import Path Resolution Property Tests', () => {
+  // Feature: sdk-protobuf-upgrade, Property 9: Import Path Resolution
+  
+  test('all protobuf imports should resolve to valid files', () => {
+    const sourceFiles = [
+      'functions/ipfs/node.ts',
+      '__tests__/functions/ipfs/node.test.js'
+    ];
+    
+    sourceFiles.forEach(sourceFile => {
+      const fullPath = path.join(__dirname, '../../', sourceFile);
+      
+      if (fs.existsSync(fullPath)) {
+        const content = fs.readFileSync(fullPath, 'utf8');
+        
+        // Extract all protobuf import paths
+        const importMatches = content.match(/require\(["']data\/protobuf\/[^"']+["']\)|from ["']data\/protobuf\/[^"']+["']/g) || [];
+        
+        importMatches.forEach(importStatement => {
+          // Extract the path
+          const pathMatch = importStatement.match(/data\/protobuf\/[^"']+/);
+          if (pathMatch) {
+            const importPath = pathMatch[0];
+            const fullImportPath = path.join(__dirname, '../../', importPath + '.ts');
+            
+            // Verify the file exists
+            expect(fs.existsSync(fullImportPath)).toBe(true);
+          }
+        });
+      }
+    });
+  });
+
+  test('CRDT imports should all point to crdt/ directory', () => {
+    const sourceFiles = [
+      'functions/ipfs/node.ts',
+      '__tests__/functions/ipfs/node.test.js'
+    ];
+    
+    sourceFiles.forEach(sourceFile => {
+      const fullPath = path.join(__dirname, '../../', sourceFile);
+      
+      if (fs.existsSync(fullPath)) {
+        const content = fs.readFileSync(fullPath, 'utf8');
+        
+        // If file mentions Delta, it should import from crdt/
+        if (content.includes('Delta')) {
+          expect(content).toMatch(/data\/protobuf\/crdt\/delta/);
+        }
+        
+        // If file mentions CRDTBroadcast, it should import from crdt/
+        if (content.includes('CRDTBroadcast')) {
+          expect(content).toMatch(/data\/protobuf\/crdt\/bcast/);
+        }
+        
+        // If file mentions Head (in CRDT context), it should import from crdt/
+        if (content.includes('Head') && content.includes('CRDT')) {
+          expect(content).toMatch(/data\/protobuf\/crdt/);
+        }
+      }
+    });
+  });
+
+  test('processing imports should point to processing/ directory', () => {
+    const sourceFiles = [
+      'functions/ipfs/node.ts',
+      'functions/messages/processing.ts'
+    ];
+    
+    sourceFiles.forEach(sourceFile => {
+      const fullPath = path.join(__dirname, '../../', sourceFile);
+      
+      if (fs.existsSync(fullPath)) {
+        const content = fs.readFileSync(fullPath, 'utf8');
+        
+        // If file mentions SGProcessing, it should reference processing/
+        if (content.includes('SGProcessing')) {
+          expect(content).toMatch(/data\/protobuf\/processing\/SGProcessing/);
+        }
+      }
+    });
+  });
+
+  test('no broken import references should exist', () => {
+    const sourceFiles = [
+      'functions/ipfs/node.ts',
+      'functions/messages/processing.ts',
+      'functions/messages/transfer.ts',
+      'functions/messages/mint.ts',
+      'functions/messages/escrow.ts',
+      'functions/messages/block.ts'
+    ];
+    
+    sourceFiles.forEach(sourceFile => {
+      const fullPath = path.join(__dirname, '../../', sourceFile);
+      
+      if (fs.existsSync(fullPath)) {
+        const content = fs.readFileSync(fullPath, 'utf8');
+        
+        // Should not have old delta path
+        expect(content).not.toMatch(/require\(["']data\/protobuf\/delta["']\)/);
+        expect(content).not.toMatch(/from ["']data\/protobuf\/delta["']/);
+        
+        // Should not have old bcast path
+        expect(content).not.toMatch(/require\(["']data\/protobuf\/bcast["']\)/);
+        expect(content).not.toMatch(/from ["']data\/protobuf\/bcast["']/);
+      }
+    });
+  });
+
+  test('all referenced protobuf files should exist', () => {
+    const requiredFiles = [
+      'data/protobuf/crdt/bcast.ts',
+      'data/protobuf/crdt/delta.ts',
+      'data/protobuf/crdt/heads.ts',
+      'data/protobuf/processing/SGProcessing.ts',
+      'data/protobuf/SGTransaction.ts',
+      'data/protobuf/SGBlocks.ts'
+    ];
+    
+    requiredFiles.forEach(filePath => {
+      const fullPath = path.join(__dirname, '../../', filePath);
+      expect(fs.existsSync(fullPath)).toBe(true);
+    });
+  });
+
+  test('protobuf directory structure should be correct', () => {
+    const protobufDir = path.join(__dirname, '../../data/protobuf');
+    expect(fs.existsSync(protobufDir)).toBe(true);
+    
+    // CRDT subdirectory should exist
+    const crdtDir = path.join(protobufDir, 'crdt');
+    expect(fs.existsSync(crdtDir)).toBe(true);
+    expect(fs.statSync(crdtDir).isDirectory()).toBe(true);
+    
+    // Processing subdirectory should exist
+    const processingDir = path.join(protobufDir, 'processing');
+    expect(fs.existsSync(processingDir)).toBe(true);
+    expect(fs.statSync(processingDir).isDirectory()).toBe(true);
+  });
+
+  test('import paths should be consistent across codebase', () => {
+    const sourceFiles = [
+      'functions/ipfs/node.ts',
+      '__tests__/functions/ipfs/node.test.js'
+    ];
+    
+    let deltaImportPath = null;
+    let bcastImportPath = null;
+    
+    sourceFiles.forEach(sourceFile => {
+      const fullPath = path.join(__dirname, '../../', sourceFile);
+      
+      if (fs.existsSync(fullPath)) {
+        const content = fs.readFileSync(fullPath, 'utf8');
+        
+        // Check Delta import path
+        const deltaMatch = content.match(/data\/protobuf\/crdt\/delta/);
+        if (deltaMatch) {
+          if (deltaImportPath === null) {
+            deltaImportPath = deltaMatch[0];
+          } else {
+            // Should be consistent
+            expect(deltaMatch[0]).toBe(deltaImportPath);
+          }
+        }
+        
+        // Check bcast import path
+        const bcastMatch = content.match(/data\/protobuf\/crdt\/bcast/);
+        if (bcastMatch) {
+          if (bcastImportPath === null) {
+            bcastImportPath = bcastMatch[0];
+          } else {
+            // Should be consistent
+            expect(bcastMatch[0]).toBe(bcastImportPath);
+          }
+        }
+      }
+    });
+    
+    // Verify we found the imports
+    expect(deltaImportPath).toBe('data/protobuf/crdt/delta');
+    expect(bcastImportPath).toBe('data/protobuf/crdt/bcast');
+  });
+});


### PR DESCRIPTION
Update node.test.ts, add comprehensive import path resolution validation tests and integration tests to validate backward compatibility and functionality preservation.

closes #15 